### PR TITLE
Add support for simple Twitter Card links

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,24 +1,28 @@
 'use strict';
 
-var rprotocol = /^https?:\/\//;
+const rprotocol = /^https?:\/\//;
+const tweetSelector = '.tweet';
+const cardLinkSelector = '.twitter-timeline-link.u-hidden:last-child';
 
 document.addEventListener('mousedown', clicked, false);
 
 function clicked (e) {
-  var a = e.target.closest('a');
-  if (a) {
-    expand(a);
-  }
+  expand(e.target.closest('a'));
 }
-
-function expand (a) {
-  var expanded = a.dataset.expandedUrl;
+function expand (a, source = a) {
+  if (!a) {
+    return;
+  }
+  const expanded = source.dataset.expandedUrl;
   if (expanded) {
     a.href = expanded;
     return;
   }
-  var title = a.title;
+  const title = source.title;
   if (rprotocol.test(title)) {
     a.href = title;
+  }
+  if (window.frameElement) {
+    expand(a, window.frameElement.closest(tweetSelector).querySelector(cardLinkSelector));
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,7 @@
   },
   "content_scripts": [{
     "matches": ["https://twitter.com/*", "https://*.twitter.com/*"],
-    "js": ["content.js"]
+    "js": ["content.js"],
+    "all_frames": true
   }]
 }


### PR DESCRIPTION
This has been tested on:
- Single-link cards https://twitter.com/SidebarIO/status/783622975396384768
- Single link but-not-last (therefore not hidden from body copy): https://twitter.com/famolus/status/783441511086075904
- Multiple links where one is transformed into a card: https://twitter.com/ChromiumDev/status/783585729226141696
- Cards with embeds (skipped): https://twitter.com/JavaScriptDaily/status/783442575139151872
- Both in the feed and permalinks
